### PR TITLE
ADD send_to_custom_email cmd

### DIFF
--- a/core/class/mail.class.php
+++ b/core/class/mail.class.php
@@ -23,17 +23,17 @@ include_file('3rdparty', 'PHPMailer/PHPMailerAutoload', 'php', 'mail');
 class mail extends eqLogic {
 
 	public function postSave() {
-		$customNumber = $this->getCmd(null, 'send_to_custom_email');
-		if (!is_object($customNumber)) {
-			$customNumber = new mailCmd();
-			$customNumber->setEqLogic_id($this->getId());
-			$customNumber->setLogicalId('send_to_custom_email');
-			$customNumber->setIsVisible(0);
-			$customNumber->setName(__('Envoyer email à', __FILE__));
-			$customNumber->setType('action');
-			$customNumber->setSubType('message');
-			$customNumber->setDisplay('cmd_with_recipient', '1');
-			$customNumber->save();
+		$customEmail = $this->getCmd(null, 'send_to_custom_email');
+		if (!is_object($customEmail)) {
+			$customEmail = new mailCmd();
+			$customEmail->setEqLogic_id($this->getId());
+			$customEmail->setLogicalId('send_to_custom_email');
+			$customEmail->setIsVisible(0);
+			$customEmail->setName(__('Envoyer email à', __FILE__));
+			$customEmail->setType('action');
+			$customEmail->setSubType('message');
+			$customEmail->setDisplay('cmd_with_recipient', '1');
+			$customEmail->save();
 		}
 	}
 }

--- a/core/template/scenario/cmd.action.message_with_recipient.html
+++ b/core/template/scenario/cmd.action.message_with_recipient.html
@@ -1,0 +1,41 @@
+<div class="input-group input-group-sm" style="width: 100%">
+    <span class="input-group-addon roundedLeft" style="width: 100px">Destinataire</span>
+    <input class="expressionAttr form-control input-sm roundedRight" data-l1key="options" data-l2key="recipient"
+        value="#recipient#" data-cmd_id="#id#" data-uid="#uid#" />
+</div>
+
+<div class="input-group input-group-sm" style="width: 100%">
+    <span class="input-group-addon roundedLeft" style="width: 100px">#title_placeholder#</span>
+    <input class="title expressionAttr form-control input-sm roundedRight" data-l1key="options" data-l2key="title"
+        value="#title#" data-cmd_id="#id#" data-uid="#uid#" />
+</div>
+
+<div class="input-group input-group-sm" style="width: 100%; padding-top: 1px">
+    <span class="input-group-addon roundedLeft" style="width: 100px">#message_placeholder#</span>
+    <textarea class="message expressionAttr form-control ta_autosize" data-l1key="options" data-l2key="message" rows="1"
+        style="resize:vertical;" data-cmd_id="#id#" data-uid="#uid#">#message#</textarea>
+    <span class="input-group-addon hasBtn roundedRight">
+        <button class="btn btn-default roundedRight listCmdMessage" type="button" tooltip="{{Sélectionner la commande}}"
+            data-cmd_id="#id#" data-uid="#uid#"><i class="fas fa-list-alt"></i></button>
+    </span>
+</div>
+
+<script>
+
+    // remove #recipient# is not set yet
+    if ('#recipient#' == '#' + 'recipient#') {
+        $('.expressionAttr[data-l1key=options][data-l2key=recipient][data-uid=#uid#]').val('');
+    }
+
+    $('.listCmdMessage[data-uid=#uid#]').on('click', function () {
+        if ('#message_cmd_subtype#' != '') {
+            jeedom.cmd.getSelectModal({ cmd: { type: '#message_cmd_type#', subType: '#message_cmd_subtype#' } }, function (result) {
+                $('.expressionAttr[data-l1key=options][data-l2key=message][data-uid=#uid#]').atCaret('insert', result.human);
+            });
+        } else {
+            jeedom.cmd.getSelectModal({ cmd: { type: '#message_cmd_type#' } }, function (result) {
+                $('.expressionAttr[data-l1key=options][data-l2key=message][data-uid=#uid#]').atCaret('insert', result.human);
+            });
+        }
+    });
+</script>


### PR DESCRIPTION
Create automatically a custom cmd 'Envoyer email à' which allows to specify the recipient directly when the cmd is used as a one shot info. No more need to create and save an email as a cmd for several uses